### PR TITLE
Add manually team assignment to spaceship

### DIFF
--- a/Appfile
+++ b/Appfile
@@ -4,3 +4,6 @@ apple_id "ios-si@wolox.com.ar"
 # Developer Portal Team ID. (ex: "RDFGA2FGMD")
 # Don't forget to change this in Matchfile also.
 team_id "7XS5GQGS29"
+
+# iTunes Connect Team ID. (ex: "18742801")
+itc_team_id "95757806"

--- a/actions/latest_testflight_version.rb
+++ b/actions/latest_testflight_version.rb
@@ -6,9 +6,14 @@ module Fastlane
 
       def self.run(params)
         Spaceship::Tunes.login
+
+        # This may be done automatically, but for some reason it has to be done manually.
+        # Open issue: https://github.com/fastlane/fastlane/issues/10944
+        Spaceship::Tunes.client.team_id = CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_id)
+
         app = Spaceship::Tunes::Application.find(params[:bundle_id])
         if app.nil?
-          UI.abort_with_message! "The application is not yet created in iTunes Connect."
+          UI.abort_with_message! "The application with bundle ID '#{params[:bundle_id]}' is not yet created in iTunes Connect."
         end
         app.all_build_train_numbers.max
       end


### PR DESCRIPTION
This PR is necessary, since `ios-si@wolox.com.ar` belongs to multiple teams.

For some reason, the team is not injected to `Spaceship` even though the property `itc_team_id` is specified in `Appfile`. 

I added a Github issue in `Fastlane` to get some help on this (please read it, more info there): https://github.com/fastlane/fastlane/issues/10944

It's important to add this in your projects to be able to continue performing releases.