### PR TITLE
Clean paths Fastfile

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -3,7 +3,6 @@ fastlane_version "2.65.0"
 default_platform :ios
 
 # Default path formatters
-project_xcconfig_path = "%s/ConfigurationFiles/%s.xcconfig"
 pem_output_path = "%s_push_certificates"
 
 # Default build configuration by action
@@ -167,7 +166,7 @@ reflected in `Info.plist` during building."
 
       desc "Get rollbar server access token from configuration file."
       rollbar_server_access_token = read_xcconfig_property(
-        xcconfig_path: project_xcconfig_path % [project_name, build_configurations[build_configuration]],
+        build_configuration: build_configurations[build_configuration],
         xcconfig_key: 'ROLLBAR_SERVER_ACCESS_TOKEN'
       )
 

--- a/Fastfile
+++ b/Fastfile
@@ -2,9 +2,6 @@
 fastlane_version "2.65.0"
 default_platform :ios
 
-# Default path formatters
-pem_output_path = "%s_push_certificates"
-
 # Default build configuration by action
 build_configurations = {
   test: "Debug",
@@ -275,7 +272,7 @@ reflected in `Info.plist` during building."
       app_identifier: bundle_identifier,
       force: false,
       p12_password: p12_password,
-      output_path: pem_output_path % build_configuration.to_s
+      output_path: "#{build_configuration.to_s}_push_certificates"
     )
   end
 

--- a/Fastfile
+++ b/Fastfile
@@ -5,7 +5,6 @@ default_platform :ios
 # Default path formatters
 project_xcconfig_path = "%s/ConfigurationFiles/%s.xcconfig"
 pem_output_path = "%s_push_certificates"
-dsym_zip_path = "%s.app.dSYM.zip"
 
 # Default build configuration by action
 build_configurations = {
@@ -180,7 +179,6 @@ reflected in `Info.plist` during building."
           access_token: rollbar_server_access_token,
           version: String(next_build_number),
           bundle_identifier: bundle_identifier,
-          dsym_zip_path: dsym_zip_path % project_name
         )
 
       end

--- a/Fastfile
+++ b/Fastfile
@@ -3,7 +3,6 @@ fastlane_version "2.65.0"
 default_platform :ios
 
 # Default path formatters
-project_plist_path = "%s/Info.plist"
 project_xcconfig_path = "%s/ConfigurationFiles/%s.xcconfig"
 pem_output_path = "%s_push_certificates"
 dsym_zip_path = "%s.app.dSYM.zip"
@@ -151,7 +150,7 @@ reflected in `Info.plist` during building."
     desc "Set version and build number in Info.plist"
     set_info_plist_version(
       version_number: current_version_version,
-      build_number: next_build_number
+      build_number: next_build_number.to_s
     )
 
     desc "Update version number in `Info.plist` depending in bump_type."
@@ -192,38 +191,10 @@ reflected in `Info.plist` during building."
     ensure
       desc "Put back the default version number and build number in `Info.plist`."
       set_info_plist_version(
-        version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
-        build_number: Actions::CheckBumpTypeAction::FIRST_BUILD
+        version_number: Actions::CheckBumpTypeAction::FIRST_VERSION.to_s,
+        build_number: Actions::CheckBumpTypeAction::FIRST_BUILD.to_s
       )
     end
-  end
-
-  desc "Sets the version and build number in the Info.plist"
-  desc "Parameters:"
-  desc "- version_number: The version to set in the Info.plist"
-  desc "- build_number: The build number to set in the Info.plist"
-
-  private_lane :set_info_plist_version do |options|
-    version_number = options[:version_number]
-    build_number = options[:build_number]
-
-    if version_number.nil? || build_number.nil?
-      UI.user_error! "Both the version and build number must be provided"
-    end
-
-    desc "Set version number in `Info.plist`."
-    set_info_plist_value(
-      path: project_plist_path % project_name,
-      key: 'CFBundleShortVersionString',
-      value: version_number.to_s
-    )
-
-    desc "Set build number in `Info.plist`."
-    set_info_plist_value(
-      path: project_plist_path % project_name,
-      key: 'CFBundleVersion',
-      value: build_number.to_s
-    )
   end
 
   desc "Executes the tests for the project using `scan`. This lane uses the configuration mapped to `:test`."

--- a/actions/read_xcconfig_property.rb
+++ b/actions/read_xcconfig_property.rb
@@ -8,12 +8,18 @@ module Fastlane
       # This is useful in case sensitive data stored in xcconfig files
       # is needed to be accessed from a fastlane script.
 
+      # Default xcconfig files path.
+      PROJECT_XCCONFIG_PATH = "%s/ConfigurationFiles/%s.xcconfig"
+
       def self.run(params)
-        if !File.exist?(params[:xcconfig_path])
+        xcconfig_path = PROJECT_XCCONFIG_PATH % [params[:project_name], params[:build_configuration]]
+
+        if !File.exist?(xcconfig_path)
+          UI.important "Configuration file at path #{xcconfig_path} not found. Please make sure the file exists."
           return nil
         end
-        line = File.open(params[:xcconfig_path])
-          .find { |each| each.start_with? params[:xcconfig_key] }
+        
+        line = File.open(xcconfig_path).find { |each| each.start_with? params[:xcconfig_key] }
         line.to_s.empty? ? nil : line.split('=').last.strip
       end
 
@@ -25,7 +31,8 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :xcconfig_path, optional: false),
+          FastlaneCore::ConfigItem.new(key: :project_name, optional: true, default_value: ProjectNameAction.default_project_name),
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false),
           FastlaneCore::ConfigItem.new(key: :xcconfig_key, optional: false),
         ]
       end

--- a/actions/set_info_plist_version.rb
+++ b/actions/set_info_plist_version.rb
@@ -1,0 +1,42 @@
+module Fastlane
+  module Actions
+    class SetInfoPlistVersionAction < Action
+
+      # Sets the version and build number in project Info.plist
+
+      # Defaul path for project Info.plist
+      PROJECT_PLIST_PATH = "%s/Info.plist".freeze
+
+      def self.run(params)
+        # Set version number in `Info.plist`
+        Actions::SetInfoPlistValueAction.run(
+          path: PROJECT_PLIST_PATH % params[:project_name],
+          key: 'CFBundleShortVersionString',
+          value: params[:version_number]
+        )
+
+        # Set build number in `Info.plist`
+        Actions::SetInfoPlistValueAction.run(
+          path: PROJECT_PLIST_PATH % params[:project_name],
+          key: 'CFBundleVersion',
+          value: params[:build_number]
+        )
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :project_name, optional: true, default_value: ProjectNameAction.default_project_name),
+          FastlaneCore::ConfigItem.new(key: :version_number, optional: false),
+          FastlaneCore::ConfigItem.new(key: :build_number, optional: false),
+        ]
+      end
+
+    end
+  end
+end

--- a/actions/upload_dsym.rb
+++ b/actions/upload_dsym.rb
@@ -8,14 +8,17 @@ module Fastlane
       # the provided configuration.
       # Returns if the upload was successful.
 
+      # Default dsym zip path used by Fastlane.
+      DSYM_ZIP_PATH = "%s.app.dSYM.zip"
+
       def self.run(params)
         # Uploads the zipped dsym file to Rollbar.
 
-      response = %x<curl -X POST "https://api.rollbar.com/api/1/dsym" \
+        response = %x<curl -X POST "https://api.rollbar.com/api/1/dsym" \
           -F access_token=#{params[:access_token]} \
           -F version=#{params[:version]} \
           -F bundle_identifier=#{params[:bundle_identifier]} \
-          -F dsym=@"#{params[:dsym_zip_path]}">
+          -F dsym=@"#{DSYM_ZIP_PATH % params[:project_name]}">
 
         # If upload was successful "error" is 0.
         # https://rollbar.com/docs/api/items_post/
@@ -35,10 +38,10 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :project_name, optional: true, default_value: ProjectNameAction.default_project_name),
           FastlaneCore::ConfigItem.new(key: :access_token, optional: false),
           FastlaneCore::ConfigItem.new(key: :version, optional: false),
           FastlaneCore::ConfigItem.new(key: :bundle_identifier, optional: false),
-          FastlaneCore::ConfigItem.new(key: :dsym_zip_path, optional: false),
         ]
       end
 


### PR DESCRIPTION
Removed path formatters from `Fastfile`.

The idea is to clean up this file removing paths formatters, and hash constants to a different place, and split `Fastfile` in different files, since it's starting to get too big.

My idea is to have a `Fastfile.private` with the private lanes, and a `Fastfile`, with the public lanes using the private ones.
