### PR TITLE
Clean dictionaries Fastfile

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -10,14 +10,6 @@ build_configurations = {
   production: "Production"
 }
 
-# Default match types by build configuration
-match_types = {
-  test: "development",
-  qa: "appstore",
-  appstore: "appstore",
-  production: "appstore"
-}
-
 platform :ios do
 
   # Run this before doing anything else
@@ -150,7 +142,7 @@ reflected in `Info.plist` during building."
       build_app(
         app_identifier: bundle_identifier,
         configuration: build_configurations[build_configuration],
-        match_type: match_types[build_configuration]
+        match_type: get_match_type(build_configuration: build_configuration)
       )
 
       desc "Get rollbar server access token from configuration file."
@@ -204,7 +196,7 @@ reflected in `Info.plist` during building."
       build_configuration: build_configurations[:test],
       app_name: get_application_name(build_configuration: :test) % project_name,
       skip_itc: true,
-      match_type: match_types[:test],
+      match_type: get_match_type(build_configuration: :test),
     )
 
     desc "Remember after this point to choose this profile in xCode Signing (Alpha)"
@@ -212,7 +204,7 @@ reflected in `Info.plist` during building."
       build_configuration: build_configurations[:qa],
       app_name: get_application_name(build_configuration: :qa) % project_name,
       skip_itc: false,
-      match_type: match_types[:qa],
+      match_type: get_match_type(build_configuration: :qa),
     )
 
   end
@@ -225,7 +217,7 @@ reflected in `Info.plist` during building."
       build_configuration: build_configurations[:appstore],
       app_name: get_application_name(build_configuration: :appstore) % project_name,
       skip_itc: false,
-      match_type: match_types[:appstore],
+      match_type: get_match_type(build_configuration: :appstore),
     )
 
   end
@@ -260,7 +252,7 @@ reflected in `Info.plist` during building."
 
     pem(
       generate_p12: true,
-      development: match_types[build_configuration] == "development",
+      development: get_match_type(build_configuration: build_configuration) == "development",
       app_identifier: bundle_identifier,
       force: false,
       p12_password: p12_password,

--- a/Fastfile
+++ b/Fastfile
@@ -18,14 +18,6 @@ match_types = {
   production: "appstore"
 }
 
-# Default App ID names by build configuration
-app_names = {
-  test: "%s Dev",
-  qa: "%s Alpha",
-  appstore: "%s",
-  production: "%s"
-}
-
 platform :ios do
 
   # Run this before doing anything else
@@ -209,16 +201,16 @@ reflected in `Info.plist` during building."
 
     desc "Remember after this point to choose this profile in xCode Signing (Development)"
     create_app(
-      app_name: app_names[:test] % project_name,
       build_configuration: build_configurations[:test],
+      app_name: get_application_name(build_configuration: :test) % project_name,
       skip_itc: true,
       match_type: match_types[:test],
     )
 
     desc "Remember after this point to choose this profile in xCode Signing (Alpha)"
     create_app(
-      app_name: app_names[:qa] % project_name,
       build_configuration: build_configurations[:qa],
+      app_name: get_application_name(build_configuration: :qa) % project_name,
       skip_itc: false,
       match_type: match_types[:qa],
     )
@@ -230,8 +222,8 @@ reflected in `Info.plist` during building."
     
     desc "Remember after this point to choose this profile in xCode Signing (Beta)"
     create_app(
-      app_name: app_names[:appstore] % project_name,
       build_configuration: build_configurations[:appstore],
+      app_name: get_application_name(build_configuration: :appstore) % project_name,
       skip_itc: false,
       match_type: match_types[:appstore],
     )

--- a/actions/get_application_name.rb
+++ b/actions/get_application_name.rb
@@ -1,0 +1,34 @@
+module Fastlane
+  module Actions
+    class GetApplicationNameAction < Action
+
+      # Given a build configuration
+      # this script returns the application name associated to it.
+
+      # Default App ID names by build configuration
+      APPLICATION_NAMES = {
+        test: "%s Dev",
+        qa: "%s Alpha",
+        appstore: "%s",
+        production: "%s"
+      }.freeze
+
+      def self.run(params)
+        APPLICATION_NAMES[params[:build_configuration]]
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false)
+        ]
+      end
+
+    end
+  end
+end

--- a/actions/get_build_configuration.rb
+++ b/actions/get_build_configuration.rb
@@ -1,0 +1,34 @@
+module Fastlane
+  module Actions
+    class GetBuildConfigurationAction < Action
+
+      # Given a build configuration action
+      # this script returns the build configuration associated to it.
+
+      # Default build configuration by action
+      BUILD_CONFIGURATIONS = {
+        test: "Debug",
+        qa: "Alpha",
+        appstore: "Release",
+        production: "Production"
+      }.freeze
+
+      def self.run(params)
+        BUILD_CONFIGURATIONS[params[:build_configuration]]
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false)
+        ]
+      end
+
+    end
+  end
+end

--- a/actions/get_match_type.rb
+++ b/actions/get_match_type.rb
@@ -1,0 +1,34 @@
+module Fastlane
+  module Actions
+    class GetMatchTypeAction < Action
+
+      # Given a build configuration
+      # this script returns the match type associated to it.
+
+      # Default match types by build configuration
+      MATCH_TYPES = {
+        test: "development",
+        qa: "appstore",
+        appstore: "appstore",
+        production: "appstore"
+      }.freeze
+
+      def self.run(params)
+        MATCH_TYPES[params[:build_configuration]]
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false)
+        ]
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Same idea as before.

Removed dictionaries from `Fastfile` and created custom actions instead.

Next step: create `Fastfile.private` and keep `Fastfile` for public lanes.