### PR TITLE
Configure project signing after creating provisioning profile

### DIFF
--- a/Fastfile.private
+++ b/Fastfile.private
@@ -200,6 +200,7 @@ reflected in `Info.plist` during building."
   end
 
   desc "Create App ID and Provisioning Profile in Member Center"
+  desc "Updates project settings using provisioning profile"
   desc "Keep these new certificates and profiles in sync with Match repository"
   private_lane :create_app do |options|
 
@@ -224,11 +225,20 @@ reflected in `Info.plist` during building."
     )
 
     desc "Generate provisioning profile if no present"
-    match(
+    match_result = match(
       app_identifier: bundle_identifier,
       type: options[:match_type],
       readonly: false
     )
+
+    desc "Update project signing identity and provisioning profile"
+    set_project_signing(
+      build_configuration: options[:build_configuration],
+      provisioning_profile: match_result[bundle_identifier],
+      development_team: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
+    )
+
+    UI.success "Project configured successfully. Please commit your changes."
 
   end
 

--- a/actions/check_bump_type.rb
+++ b/actions/check_bump_type.rb
@@ -37,7 +37,7 @@ module Fastlane
         # As long as the user chooses a non allowed bump type, ask again until a valid one is provided.
         bump_type = params[:bump_type]
         while not allowed_bump_types.include? bump_type do
-          bump_type = UI.input "Choose the `bump_type` representing the type of deploy. It can be any of %s" % allowed_bump_types.to_s
+          bump_type = UI.input "Choose the `bump_type` representing the type of deploy. It can be any of #{allowed_bump_types.to_s}"
           bump_type = bump_type.to_sym
         end
 

--- a/actions/project_name.rb
+++ b/actions/project_name.rb
@@ -35,10 +35,10 @@ module Fastlane
       def self.default_project
         projects = Dir.entries('.').select { |each| File.extname(each) == PROJECT_EXTENSION }
         if projects.length == 0
-          UI.abort_with_message! "No projects with extension %s found in root directory." % PROJECT_EXTENSION
+          UI.abort_with_message! "No projects with extension '#{PROJECT_EXTENSION}' found in root directory."
         end
         if projects.length > 1
-          UI.abort_with_message! "Multiple projects with extension %s found in root directory." % PROJECT_EXTENSION
+          UI.abort_with_message! "Multiple projects with extension '#{PROJECT_EXTENSION}' found in root directory."
         end
         projects.first
       end
@@ -51,7 +51,7 @@ module Fastlane
           .targets
           .find { |each| each.name == File.basename(default_project, File.extname(default_project)) }
         if target.nil?
-          UI.abort_with_message! "No target matching project name %s found." % PROJECT_EXTENSION
+          UI.abort_with_message! "No target matching project name '#{PROJECT_EXTENSION}' found."
         end
         target.name
       end

--- a/actions/set_info_plist_version.rb
+++ b/actions/set_info_plist_version.rb
@@ -7,18 +7,21 @@ module Fastlane
       # Defaul path for project Info.plist
       PROJECT_PLIST_PATH = "%s/Info.plist".freeze
 
+      VERSION_NUMBER_KEY = 'CFBundleShortVersionString'
+      BUILD_NUMBER_KEY = 'CFBundleVersion'
+
       def self.run(params)
         # Set version number in `Info.plist`
         Actions::SetInfoPlistValueAction.run(
           path: PROJECT_PLIST_PATH % params[:project_name],
-          key: 'CFBundleShortVersionString',
+          key: VERSION_NUMBER_KEY,
           value: params[:version_number]
         )
 
         # Set build number in `Info.plist`
         Actions::SetInfoPlistValueAction.run(
           path: PROJECT_PLIST_PATH % params[:project_name],
-          key: 'CFBundleVersion',
+          key: BUILD_NUMBER_KEY,
           value: params[:build_number]
         )
       end

--- a/actions/set_project_signing.rb
+++ b/actions/set_project_signing.rb
@@ -8,13 +8,16 @@ module Fastlane
       # this script updates the provisioning profile and development team
       # to have proper signing identities in xCode.
 
+      PROVISIONING_PROFILE_SPECIFIER = 'PROVISIONING_PROFILE_SPECIFIER'
+      DEVELOPMENT_TEAM = 'DEVELOPMENT_TEAM'
+
       def self.run(params)
         # Set provisioning profile in xCode
         Actions::UpdateProjectPropertyAction.run(
           project: params[:project],
           scheme: params[:scheme],
           build_configuration: params[:build_configuration],
-          build_setting: 'PROVISIONING_PROFILE_SPECIFIER',
+          build_setting: PROVISIONING_PROFILE_SPECIFIER,
           build_setting_value: params[:provisioning_profile]
         )
 
@@ -23,7 +26,7 @@ module Fastlane
           project: params[:project],
           scheme: params[:scheme],
           build_configuration: params[:build_configuration],
-          build_setting: 'DEVELOPMENT_TEAM',
+          build_setting: DEVELOPMENT_TEAM,
           build_setting_value: params[:development_team]
         )
       end

--- a/actions/set_project_signing.rb
+++ b/actions/set_project_signing.rb
@@ -1,0 +1,49 @@
+require 'xcodeproj'
+
+module Fastlane
+  module Actions
+    class SetProjectSigningAction < Action
+
+      # Given a project, a scheme, and a build configuration
+      # this script updates the provisioning profile and development team
+      # to have proper signing identities in xCode.
+
+      def self.run(params)
+        # Set provisioning profile in xCode
+        Actions::UpdateProjectPropertyAction.run(
+          project: params[:project],
+          scheme: params[:scheme],
+          build_configuration: params[:build_configuration],
+          build_setting: 'PROVISIONING_PROFILE_SPECIFIER',
+          build_setting_value: params[:provisioning_profile]
+        )
+
+        # Set development team in xCode
+        Actions::UpdateProjectPropertyAction.run(
+          project: params[:project],
+          scheme: params[:scheme],
+          build_configuration: params[:build_configuration],
+          build_setting: 'DEVELOPMENT_TEAM',
+          build_setting_value: params[:development_team]
+        )
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :project, optional: true, default_value: ProjectNameAction.default_project_filename),
+          FastlaneCore::ConfigItem.new(key: :scheme, optional: true, default_value: ProjectNameAction.default_project_name),
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false),
+          FastlaneCore::ConfigItem.new(key: :provisioning_profile, optional: false),
+          FastlaneCore::ConfigItem.new(key: :development_team, optional: false),
+        ]
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Project `team` and `provisioning profile` is set automatically after creating provisioning profile using match.

One less step that has to be done manually =)