### PR TITLE
Clean Fastfile providing private lanes only build configuration

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -43,7 +43,7 @@ platform :ios do
 
   desc "Executes the tests for the project using `scan`. This lane uses the configuration mapped to `:test`."
   lane :test do
-    run_tests build_configuration_key: :test
+    run_tests build_configuration: :test
   end
 
   desc "Creates the `App ID` and `Provisioning Profile` for the configurations mapped to `:test` and `:qa`."
@@ -59,7 +59,7 @@ platform :ios do
 
   desc "Creates the `App ID` and `Provisioning Profile` for the configuration mapped to `:production`."
   lane :create_external_appstore_app do
-    create_app build_configuration_key: :production
+    create_app build_configuration: :production
   end
 
   desc "Generates the push notifications certificates for the build configurations mapped to `:test` and `:qa`."

--- a/Fastfile
+++ b/Fastfile
@@ -1,5 +1,5 @@
 import 'Fastfile.private'
-fastlane_version "2.65.0"
+fastlane_version '2.66.0'
 default_platform :ios
 
 platform :ios do

--- a/Fastfile
+++ b/Fastfile
@@ -4,22 +4,19 @@ default_platform :ios
 
 platform :ios do
 
-  desc "Run this before doing anything else"
-  desc "Perform project configurations validations."
+  desc "Before doing anything else."
   before_all do
     validate
   end
 
-  desc "After all the steps have completed succesfully, run this."
-  desc "Remove all build artifacts created by fastlane to upload."
+  desc "After all the steps have completed succesfully."
   after_all do |lane|
-    clean_build_artifacts
+    clean
   end
 
-  desc "If there was an error, run this."
-  desc "Remove all build artifacts created by fastlane to upload."
+  desc "If there was an error."
   error do |lane, exception|
-    clean_build_artifacts
+    clean
   end
 
   desc "New release to iTunes Connect for QA (Alpha). This lane will never update the version, only the build number."

--- a/Fastfile
+++ b/Fastfile
@@ -4,93 +4,78 @@ default_platform :ios
 
 platform :ios do
 
-  # Run this before doing anything else
+  desc "Run this before doing anything else"
+  desc "Perform project configurations validations."
   before_all do
-
-    desc "Perform project configurations validations."
     validate
-    
   end
 
-  # After all the steps have completed succesfully, run this.
+  desc "After all the steps have completed succesfully, run this."
+  desc "Remove all build artifacts created by fastlane to upload."
   after_all do |lane|
-
-    desc "Remove all build artifacts created by fastlane to upload."
     clean_build_artifacts
-
   end
 
-  # If there was an error, run this.
+  desc "If there was an error, run this."
+  desc "Remove all build artifacts created by fastlane to upload."
   error do |lane, exception|
-
-    desc "Remove all build artifacts created by fastlane to upload."
     clean_build_artifacts
-
   end
 
-  desc "New release to `TestFlight` for QA(Alpha). This lane will never update the version, only the build number."
+  desc "New release to iTunes Connect for QA (Alpha). This lane will never update the version, only the build number."
   lane :release_qa do
     release build_configuration: :qa
   end
 
-  desc "New release to `TestFlight` for Appstore."
+  desc "New release to iTunes Connect for AppStore (Release) in Wolox account."
   desc "Parameters:"
   desc "- bump_type (optional): represents the type of deploy. If not specified, the user will be asked for it."
-  lane :release_appstore do |options|
+  lane :release_internal_appstore do |options|
     release build_configuration: :appstore, bump_type: options[:bump_type]
+  end
+
+  desc "New release to iTunes Connect for AppStore (Production) in third party account."
+  desc "Parameters:"
+  desc "- bump_type (optional): represents the type of deploy. If not specified, the user will be asked for it."
+  lane :release_external_appstore do |options|
+    release build_configuration: :production, bump_type: options[:bump_type]
   end
 
   desc "Executes the tests for the project using `scan`. This lane uses the configuration mapped to `:test`."
   lane :test do
-
-    desc "Run scan with default project and scheme"
-    run_tests
-
+    run_tests build_configuration_key: :test
   end
 
   desc "Creates the `App ID` and `Provisioning Profile` for the configurations mapped to `:test` and `:qa`."
   lane :create_development_app do
-
-    desc "Remember after this point to choose this profile in xCode Signing (Development)"
-    create_app(
-      app_name: get_application_name(build_configuration: :test) % project_name,
-      build_configuration: get_build_configuration(build_configuration: :test),
-      skip_itc: true,
-      match_type: get_match_type(build_configuration: :test),
-    )
-
-    desc "Remember after this point to choose this profile in xCode Signing (Alpha)"
-    create_app(
-      app_name: get_application_name(build_configuration: :qa) % project_name,
-      build_configuration: get_build_configuration(build_configuration: :qa),
-      skip_itc: false,
-      match_type: get_match_type(build_configuration: :qa),
-    )
-
+    create_app build_configuration: :test
+    create_app build_configuration: :qa
   end
 
   desc "Creates the `App ID` and `Provisioning Profile` for the configuration mapped to `:appstore`."
-  lane :create_appstore_app do
-    
-    desc "Remember after this point to choose this profile in xCode Signing (Beta)"
-    create_app(
-      app_name: get_application_name(build_configuration: :appstore) % project_name,
-      build_configuration: get_build_configuration(build_configuration: :appstore),
-      skip_itc: false,
-      match_type: get_match_type(build_configuration: :appstore),
-    )
+  lane :create_internal_appstore_app do
+    create_app build_configuration: :appstore
+  end
 
+  desc "Creates the `App ID` and `Provisioning Profile` for the configuration mapped to `:production`."
+  lane :create_external_appstore_app do
+    create_app build_configuration_key: :production
   end
 
   desc "Generates the push notifications certificates for the build configurations mapped to `:test` and `:qa`."
-  lane :generate_push_certificates_development do |options|
+  lane :generate_push_certificates_development do
     generate_push_certificates build_configuration: :test
     generate_push_certificates build_configuration: :qa
   end
 
   desc "Generates the push notifications certificates for the build configurations mapped to `:appstore`."
-  lane :generate_push_certificates_appstore do |options|
+  lane :generate_push_certificates_internal_appstore do
     generate_push_certificates build_configuration: :appstore
+  end
+
+  desc "Generates the push notifications certificates for the build configurations mapped to `:production`."
+  lane :generate_push_certificates_external_appstore do
+    generate_push_certificates build_configuration: :production
   end
 
   desc "Adds a new device and regenerates the `Provisioning Profile`s to include it."

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -72,7 +72,7 @@ reflected in `Info.plist` during building."
     end
 
     desc "Read current build number from `TestFlight`."
-    current_build_version = latest_testflight_build_number(
+    current_build_number = latest_testflight_build_number(
       app_identifier: bundle_identifier,
       version: current_version_number,
       initial_build_number: Actions::CheckBumpTypeAction::FIRST_BUILD
@@ -87,7 +87,7 @@ reflected in `Info.plist` during building."
     UI.message "Will release app increasing bump type: `#{bump_type}`"
 
     desc "Define next build number depending on bump_type."
-    current_build_number = bump_type == "build" ? current_build_version : Actions::CheckBumpTypeAction::FIRST_BUILD
+    current_build_number = bump_type == "build" ? current_build_number : Actions::CheckBumpTypeAction::FIRST_BUILD
     next_build_number = current_build_number + 1
 
     desc "Set version and build number in Info.plist"

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -64,23 +64,23 @@ reflected in `Info.plist` during building."
     )
 
     desc "Read current version number from `TestFlight`."
-    current_version_version = latest_testflight_version(
+    current_version_number = latest_testflight_version(
       bundle_id: bundle_identifier
     )
-    if current_version_version.nil?
-      current_version_version = Actions::CheckBumpTypeAction::FIRST_VERSION
+    if current_version_number.nil?
+      current_version_number = Actions::CheckBumpTypeAction::FIRST_VERSION
     end
 
     desc "Read current build number from `TestFlight`."
     current_build_version = latest_testflight_build_number(
       app_identifier: bundle_identifier,
-      version: current_version_version,
+      version: current_version_number,
       initial_build_number: Actions::CheckBumpTypeAction::FIRST_BUILD
     ).to_i
 
     bump_type = check_bump_type(
       build_configuration: build_configuration_key,
-      version: current_version_version,
+      version: current_version_number,
       bump_type: options[:bump_type]
     ).to_s
 
@@ -92,13 +92,13 @@ reflected in `Info.plist` during building."
 
     desc "Set version and build number in Info.plist"
     set_info_plist_version(
-      version_number: current_version_version,
+      version_number: current_version_number,
       build_number: next_build_number.to_s
     )
 
     desc "Update version number in `Info.plist` depending in bump_type."
     if bump_type != "build"
-      current_version_version = increment_version_number(bump_type: bump_type)
+      current_version_number = increment_version_number(bump_type: bump_type)
     end
 
     begin
@@ -126,7 +126,7 @@ reflected in `Info.plist` during building."
       end
 
       desc "Upload the built app to TestFlight."
-      UI.message "Uploading version `#{current_version_version}` build `#{next_build_number}`"
+      UI.message "Uploading version `#{current_version_number}` build `#{next_build_number}`"
       publish_testflight
     ensure
       desc "Put back the default version number and build number in `Info.plist`."

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -74,11 +74,9 @@ reflected in `Info.plist` during building."
 
     desc "Read current version number from `TestFlight`."
     current_version_number = latest_testflight_version(
-      bundle_id: bundle_identifier
+      bundle_id: bundle_identifier,
+      initial_version_number: Actions::CheckBumpTypeAction::FIRST_VERSION
     )
-    if current_version_number.nil?
-      current_version_number = Actions::CheckBumpTypeAction::FIRST_VERSION
-    end
 
     desc "Read current build number from `TestFlight`."
     current_build_number = latest_testflight_build_number(

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -49,16 +49,17 @@ reflected in `Info.plist` during building."
   desc "First deploy must always be a `%s`" % :major
   private_lane :release do |options|
 
-    build_configuration = options[:build_configuration]
+    build_configuration_key = options[:build_configuration]
+    build_configuration = get_build_configuration(build_configuration: build_configuration_key)
 
-    if Actions::CheckBumpTypeAction.bump_type_allowed? build_configuration, options[:bump_type]
-      allowed_bump_types = Actions::CheckBumpTypeAction::BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES[build_configuration]
+    if Actions::CheckBumpTypeAction.bump_type_allowed? build_configuration_key, options[:bump_type]
+      allowed_bump_types = Actions::CheckBumpTypeAction::BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES[build_configuration_key]
       UI.user_error! "The bump_type specified for this lane can only be one of `%s`" % allowed_bump_types.to_s
     end
 
     desc "Read bundle identifier from project configuration."
     bundle_identifier = read_project_property(
-      build_configuration: get_build_configuration(build_configuration: build_configuration),
+      build_configuration: build_configuration,
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
@@ -78,12 +79,12 @@ reflected in `Info.plist` during building."
     ).to_i
 
     bump_type = check_bump_type(
-      build_configuration: build_configuration,
+      build_configuration: build_configuration_key,
       version: current_version_version,
       bump_type: options[:bump_type]
     ).to_s
 
-    UI.message "Will release app increasing bump type: `%s`" % bump_type
+    UI.message "Will release app increasing bump type: `#{bump_type}`"
 
     desc "Define next build number depending on bump_type."
     current_build_number = bump_type == "build" ? current_build_version : Actions::CheckBumpTypeAction::FIRST_BUILD
@@ -103,14 +104,12 @@ reflected in `Info.plist` during building."
     begin
       desc "Build"
       build_app(
-        app_identifier: bundle_identifier,
-        build_configuration: get_build_configuration(build_configuration: build_configuration),
-        match_type: get_match_type(build_configuration: build_configuration)
+        build_configuration: build_configuration_key
       )
 
       desc "Get rollbar server access token from configuration file."
       rollbar_server_access_token = read_xcconfig_property(
-        build_configuration: get_build_configuration(build_configuration: build_configuration),
+        build_configuration: build_configuration,
         xcconfig_key: 'ROLLBAR_SERVER_ACCESS_TOKEN'
       )
 
@@ -127,7 +126,7 @@ reflected in `Info.plist` during building."
       end
 
       desc "Upload the built app to TestFlight."
-      UI.message "Uploading version `%s` build `%s`" % [current_version_version, next_build_number]
+      UI.message "Uploading version `#{current_version_version}` build `#{next_build_number}`"
       publish_testflight
     ensure
       desc "Put back the default version number and build number in `Info.plist`."
@@ -138,12 +137,15 @@ reflected in `Info.plist` during building."
     end
   end
 
-  desc "Executes the tests for the project using `scan`. This lane uses the configuration mapped to `:test`."
-  private_lane :run_tests do
+  desc "Executes the tests for the project using `scan`."
+  private_lane :run_tests do |options|
+
+    build_configuration_key = options[:build_configuration]
+    build_configuration = get_build_configuration(build_configuration: build_configuration)
 
     desc "Run scan with default project and scheme"
     scan(
-      configuration: get_build_configuration(build_configuration: :test),
+      configuration: build_configuration,
       # Because of a supposed Apple bug, CI builds fail if it doesn't run in iPhoneSE: travis-ci/travis-ci#6422
       devices: ['iPhone SE'],
       clean: false
@@ -155,13 +157,25 @@ reflected in `Info.plist` during building."
   desc "It uses the same password stored in keychain for the current user."
   desc "Make sure to store safely the output of this command in the right `Google Drive` folder."
   private_lane :generate_push_certificates do |options|
-    build_configuration = options[:build_configuration]
+
+    build_configuration_key = options[:build_configuration]
+    build_configuration = get_build_configuration(build_configuration: build_configuration_key)
+    match_type = get_match_type(build_configuration: build_configuration_key)
+    is_development = match_type == Actions::GetMatchTypeAction::MATCH_TYPES[:test]
+    output_path = "#{build_configuration_key.to_s}_push_certificates"
 
     desc "Bundle identifier from xCode project"
     bundle_identifier = read_project_property(
-      build_configuration: get_build_configuration(build_configuration: build_configuration),
+      build_configuration: build_configuration,
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
+
+    UI.message "Attempting to create push certificates for build configuration '#{build_configuration}'"
+    UI.message "Creating push certificates as: '#{is_development ? 'development' : 'production'}' and bundle ID: '#{bundle_identifier}'"
+    confirmation = UI.input "If the parameters are correct, proceed: Y/n"
+    unless confirmation.empty? || confirmation.downcase == "y"
+      UI.user_error! "Aborting due to parameters misconfiguration. Correct them and run the lane again."
+    end
 
     desc "Password for current user from keychain"
     user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
@@ -170,27 +184,38 @@ reflected in `Info.plist` during building."
 
     pem(
       generate_p12: true,
-      development: get_match_type(build_configuration: build_configuration) == "development",
+      development: is_development,
       app_identifier: bundle_identifier,
       force: false,
       p12_password: p12_password,
-      output_path: "#{build_configuration.to_s}_push_certificates"
+      output_path: output_path
     )
+
   end
 
   desc "Builds the app creating the `.ipa` and `.dsym` files"
   private_lane :build_app do |options|
 
+    build_configuration_key = options[:build_configuration]
+    build_configuration = get_build_configuration(build_configuration: build_configuration_key)
+    match_type = get_match_type(build_configuration: build_configuration_key)
+
+    desc "Bundle identifier from xCode project"
+    bundle_identifier = read_project_property(
+      build_configuration: build_configuration,
+      build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
+    )
+
     desc "Download provisioning profiles"
     match(
-      app_identifier: options[:app_identifier],
-      type: options[:match_type],
+      app_identifier: bundle_identifier,
+      type: match_type,
       readonly: true
     )
 
     desc "Build the app using default project and scheme"
     gym(
-      configuration: options[:build_configuration],
+      configuration: build_configuration,
       include_symbols: true,
       # bitcode is disabled for the dsym file to keep valid after app is uploaded to app store
       # http://krausefx.com/blog/download-dsym-symbolication-files-from-itunes-connect-for-bitcode-ios-apps
@@ -204,14 +229,22 @@ reflected in `Info.plist` during building."
   desc "Keep these new certificates and profiles in sync with Match repository"
   private_lane :create_app do |options|
 
+    build_configuration_key = options[:build_configuration]
+    build_configuration = get_build_configuration(build_configuration: build_configuration_key)
+    app_name = get_application_name(build_configuration: build_configuration_key) % project_name
+    skip_itc = build_configuration_key == :test
+    match_type = get_match_type(build_configuration: build_configuration_key)
+
     desc "Bundle identifier from xCode project"
     bundle_identifier = read_project_property(
-      build_configuration: options[:build_configuration],
+      build_configuration: build_configuration,
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
-    UI.message "Attempting to create application for build configuration '#{options[:build_configuration]}'."
-    UI.message "Using name: '#{options[:app_name]}' and bundle ID: '#{bundle_identifier}'"
+    UI.message "Attempting to create application for build configuration '#{build_configuration}'"
+    UI.message "Creating application using name: '#{app_name}' and bundle ID: '#{bundle_identifier}'"
+    UI.message "The application creation in iTunes Connect will be #{skip_itc ? 'skipped' : 'performed'}"
+    UI.message "Creating profile with match type '#{match_type}' and bundle ID: '#{bundle_identifier}'"
     confirmation = UI.input "If the parameters are correct, proceed: Y/n"
     unless confirmation.empty? || confirmation.downcase == "y"
       UI.user_error! "Aborting due to parameters misconfiguration. Correct them and run the lane again."
@@ -219,21 +252,21 @@ reflected in `Info.plist` during building."
 
     desc "Create App ID in developer center"
     produce(
-      app_name: options[:app_name],
+      app_name: app_name,
       app_identifier: bundle_identifier,
-      skip_itc: options[:skip_itc]
+      skip_itc: skip_itc
     )
 
     desc "Generate provisioning profile if no present"
     match_result = match(
       app_identifier: bundle_identifier,
-      type: options[:match_type],
+      type: match_type,
       readonly: false
     )
 
     desc "Update project signing identity and provisioning profile"
     set_project_signing(
-      build_configuration: options[:build_configuration],
+      build_configuration: build_configuration,
       provisioning_profile: match_result[bundle_identifier],
       development_team: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
     )

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -238,7 +238,7 @@ reflected in `Info.plist` during building."
 
     build_configuration_key = options[:build_configuration]
     build_configuration = get_build_configuration(build_configuration: build_configuration_key)
-    app_name = get_application_name(build_configuration: build_configuration_key) % project_name
+    app_name = get_application_name(build_configuration: build_configuration_key)
     skip_itc = build_configuration_key == :test
     match_type = get_match_type(build_configuration: build_configuration_key)
 

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -18,7 +18,7 @@ platform :ios do
         build_configuration: key, 
         build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
       )
-      UI.message "Validating bundle identifier for '#{key}'. Expected: '#{value}', found: '#{found_bundle_identifier}'."
+      UI.message "Validating bundle identifier for '#{key}'. Expected any of: '#{value}', found: '#{found_bundle_identifier}'."
       unless value.include?(found_bundle_identifier)
         UI.abort_with_message! "Aborting due to mismatching in bundle identifier for build configuration '#{value}'."
       end

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -85,6 +85,7 @@ reflected in `Info.plist` during building."
       initial_build_number: Actions::CheckBumpTypeAction::FIRST_BUILD
     ).to_i
 
+    desc "Check bump type to use for next build."
     bump_type = check_bump_type(
       build_configuration: build_configuration_key,
       version: current_version_number,

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -141,7 +141,7 @@ reflected in `Info.plist` during building."
   private_lane :run_tests do |options|
 
     build_configuration_key = options[:build_configuration]
-    build_configuration = get_build_configuration(build_configuration: build_configuration)
+    build_configuration = get_build_configuration(build_configuration: build_configuration_key)
 
     desc "Run scan with default project and scheme"
     scan(

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -5,7 +5,7 @@ platform :ios do
   private_lane :validate do
 
     desc "Validate the project name and main target are properly configured."
-    UI.message "Running lane for project: `%s`" % project_name
+    UI.message "Running lane for project: '#{project_name}'."
 
     desc "Validate the configured bundle identifiers match the expected ones."
     build_configurations = Actions::GetBuildConfigurationAction::BUILD_CONFIGURATIONS
@@ -24,13 +24,22 @@ platform :ios do
       end
     end
 
+    UI.success "Project validations succeeded!"
+
+  end
+
+  private_lane :clean do
+
+    UI.message "Removing all build artifacts created by fastlane."
+    clean_build_artifacts
+
   end
 
   desc "Releases a new version to `TestFlight`. This lane must receive the following parameters:"
   desc "- build_configuration: A build configuration to deploy. \
 Can be any of: `%s`" % Actions::GetBuildConfigurationAction::BUILD_CONFIGURATIONS.keys.to_s
   desc "- bump_type (optional): represents the type of deploy. If not specified, the user will be asked for it.
-  Its allowed values depend on the configuration: `%s`" % Actions::CheckBumpTypeAction::BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES.to_s
+  Its allowed values depend on the configuration: '#{Actions::CheckBumpTypeAction::BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES.to_s}'."
   desc ""
   desc "It has basically 3 main responsabilities: build/version number managing, app building, and deploy."
   desc ""
@@ -44,9 +53,9 @@ reflected in `Info.plist` during building."
   desc "- Uploads the application to `TestFlight` using `pilot`."
   desc ""
   desc "Check [here](http://semver.org/) for reference about versioning."
-  desc "Build is initialized in `%s`" % Actions::CheckBumpTypeAction::FIRST_BUILD
-  desc "Version is initialized in `%s`" % Actions::CheckBumpTypeAction::FIRST_VERSION
-  desc "First deploy must always be a `%s`" % :major
+  desc "Build is initialized in '#{Actions::CheckBumpTypeAction::FIRST_BUILD}'."
+  desc "Version is initialized in '#{Actions::CheckBumpTypeAction::FIRST_VERSION}'."
+  desc "First deploy must always be a '#{:major}'."
   private_lane :release do |options|
 
     build_configuration_key = options[:build_configuration]
@@ -54,7 +63,7 @@ reflected in `Info.plist` during building."
 
     if Actions::CheckBumpTypeAction.bump_type_allowed? build_configuration_key, options[:bump_type]
       allowed_bump_types = Actions::CheckBumpTypeAction::BUILD_CONFIGURATION_ALLOWED_BUMP_TYPES[build_configuration_key]
-      UI.user_error! "The bump_type specified for this lane can only be one of `%s`" % allowed_bump_types.to_s
+      UI.user_error! "The bump_type specified for this lane can only be one of '#{allowed_bump_types.to_s}'."
     end
 
     desc "Read bundle identifier from project configuration."

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -111,7 +111,7 @@ reflected in `Info.plist` during building."
 
     begin
       desc "Build"
-      build_app(
+      build_application(
         build_configuration: build_configuration_key
       )
 
@@ -146,7 +146,7 @@ reflected in `Info.plist` during building."
   end
 
   desc "Executes the tests for the project using `scan`."
-  private_lane :run_tests do |options|
+  private_lane :run_application_tests do |options|
 
     build_configuration_key = options[:build_configuration]
     build_configuration = get_build_configuration(build_configuration: build_configuration_key)
@@ -202,7 +202,7 @@ reflected in `Info.plist` during building."
   end
 
   desc "Builds the app creating the `.ipa` and `.dsym` files"
-  private_lane :build_app do |options|
+  private_lane :build_application do |options|
 
     build_configuration_key = options[:build_configuration]
     build_configuration = get_build_configuration(build_configuration: build_configuration_key)

--- a/README.md
+++ b/README.md
@@ -39,17 +39,11 @@ Adds a new device and regenerates the `Provisioning Profile`s to include it.
 ```
 fastlane ios release_qa
 ```
-Run this before doing anything else
+Before doing anything else.
 
-Perform project configurations validations.
+After all the steps have completed succesfully.
 
-After all the steps have completed succesfully, run this.
-
-Remove all build artifacts created by fastlane to upload.
-
-If there was an error, run this.
-
-Remove all build artifacts created by fastlane to upload.
+If there was an error.
 
 New release to iTunes Connect for QA (Alpha). This lane will never update the version, only the build number.
 ### ios release_internal_appstore

--- a/README.md
+++ b/README.md
@@ -30,20 +30,46 @@ xcode-select --install
 
 # Available Actions
 ## iOS
-### ios release_appstore
+### ios add_single_device
 ```
-fastlane ios release_appstore
+fastlane ios add_single_device
 ```
-New release to `TestFlight` for Appstore.
-
-Parameters:
-
-- bump_type (optional): represents the type of deploy. If not specified, the user will be asked for it.
+Adds a new device and regenerates the `Provisioning Profile`s to include it.
 ### ios release_qa
 ```
 fastlane ios release_qa
 ```
-New release to `TestFlight` for QA(Alpha). This lane will never update the version, only the build number.
+Run this before doing anything else
+
+Perform project configurations validations.
+
+After all the steps have completed succesfully, run this.
+
+Remove all build artifacts created by fastlane to upload.
+
+If there was an error, run this.
+
+Remove all build artifacts created by fastlane to upload.
+
+New release to iTunes Connect for QA (Alpha). This lane will never update the version, only the build number.
+### ios release_internal_appstore
+```
+fastlane ios release_internal_appstore
+```
+New release to iTunes Connect for AppStore (Release) in Wolox account.
+
+Parameters:
+
+- bump_type (optional): represents the type of deploy. If not specified, the user will be asked for it.
+### ios release_external_appstore
+```
+fastlane ios release_external_appstore
+```
+New release to iTunes Connect for AppStore (Production) in third party account.
+
+Parameters:
+
+- bump_type (optional): represents the type of deploy. If not specified, the user will be asked for it.
 ### ios test
 ```
 fastlane ios test
@@ -54,21 +80,31 @@ Executes the tests for the project using `scan`. This lane uses the configuratio
 fastlane ios create_development_app
 ```
 Creates the `App ID` and `Provisioning Profile` for the configurations mapped to `:test` and `:qa`.
-### ios create_appstore_app
+### ios create_internal_appstore_app
 ```
-fastlane ios create_appstore_app
+fastlane ios create_internal_appstore_app
 ```
 Creates the `App ID` and `Provisioning Profile` for the configuration mapped to `:appstore`.
+### ios create_external_appstore_app
+```
+fastlane ios create_external_appstore_app
+```
+Creates the `App ID` and `Provisioning Profile` for the configuration mapped to `:production`.
 ### ios generate_push_certificates_development
 ```
 fastlane ios generate_push_certificates_development
 ```
 Generates the push notifications certificates for the build configurations mapped to `:test` and `:qa`.
-### ios generate_push_certificates_appstore
+### ios generate_push_certificates_internal_appstore
 ```
-fastlane ios generate_push_certificates_appstore
+fastlane ios generate_push_certificates_internal_appstore
 ```
 Generates the push notifications certificates for the build configurations mapped to `:appstore`.
+### ios generate_push_certificates_external_appstore
+```
+fastlane ios generate_push_certificates_external_appstore
+```
+Generates the push notifications certificates for the build configurations mapped to `:production`.
 ### ios add_device
 ```
 fastlane ios add_device

--- a/actions/get_application_name.rb
+++ b/actions/get_application_name.rb
@@ -14,7 +14,7 @@ module Fastlane
       }.freeze
 
       def self.run(params)
-        APPLICATION_NAMES[params[:build_configuration]]
+        APPLICATION_NAMES[params[:build_configuration]] % params[:project_name]
       end
 
       # Fastlane Action class required functions.
@@ -25,7 +25,8 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false)
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false),
+          FastlaneCore::ConfigItem.new(key: :project_name, optional: true, default_value: ProjectNameAction.default_project_name),
         ]
       end
 

--- a/actions/latest_testflight_version.rb
+++ b/actions/latest_testflight_version.rb
@@ -15,7 +15,7 @@ module Fastlane
         if app.nil?
           UI.abort_with_message! "The application with bundle ID '#{params[:bundle_id]}' is not yet created in iTunes Connect."
         end
-        app.all_build_train_numbers.max
+        app.all_build_train_numbers.max || params[:initial_version_number]
       end
 
       # Fastlane Action class required functions.
@@ -27,6 +27,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :bundle_id, optional: false),
+          FastlaneCore::ConfigItem.new(key: :initial_version_number, optional: false),
         ]
       end
 


### PR DESCRIPTION
Cleaned `Fastfile`. Provide private lanes only build configuration.

This is the last step before being able to infer based on it the properties that depend on each team. So far, we have to manually comment/uncomment them in the configuration files. Now, it will be possible to infer which one we want to read based on build configuration in use.

Also, the `Fastfile` seems much cleaner!

