### PR TITLE
Add lanes to refresh provisioning profiles and certificates

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -75,18 +75,18 @@ platform :ios do
     generate_push_certificates build_configuration: :production
   end
 
-  desc "Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:test` and `:qa`."
+  desc "Updates or downloads the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:test` and `:qa`."
   lane :refresh_development_certificates do
     refresh_certificates build_configuration: :test
     refresh_certificates build_configuration: :qa
   end
 
-  desc "Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:appstore`."
+  desc "Updates or downloads the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:appstore`."
   lane :refresh_internal_appstore_certificates do
     refresh_certificates build_configuration: :appstore
   end
 
-  desc "Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:production`."
+  desc "Updates or downloads the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:production`."
   lane :refresh_external_appstore_certificates do
     refresh_certificates build_configuration: :production
   end

--- a/Fastfile
+++ b/Fastfile
@@ -75,6 +75,22 @@ platform :ios do
     generate_push_certificates build_configuration: :production
   end
 
+  desc "Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:test` and `:qa`."
+  lane :refresh_development_certificates do
+    refresh_certificates build_configuration: :test
+    refresh_certificates build_configuration: :qa
+  end
+
+  desc "Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:appstore`."
+  lane :refresh_internal_appstore_certificates do
+    refresh_certificates build_configuration: :appstore
+  end
+
+  desc "Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:production`."
+  lane :refresh_external_appstore_certificates do
+    refresh_certificates build_configuration: :production
+  end
+
   desc "Adds a new device and regenerates the `Provisioning Profile`s to include it."
   lane :add_device do
     add_single_device

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -283,6 +283,28 @@ reflected in `Info.plist` during building."
 
   end
 
+  desc "Refreshes the `Certificates` and `Provisioning Profiles`."
+  private_lane :refresh_certificates do |options|
+
+    build_configuration_key = options[:build_configuration]
+    build_configuration = get_build_configuration(build_configuration: build_configuration_key)
+    match_type = get_match_type(build_configuration: build_configuration_key)
+ 
+    desc "Bundle identifier from xCode project"
+    bundle_identifier = read_project_property(
+      build_configuration: build_configuration,
+      build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
+    )
+
+    desc "Download provisioning profile and certificates if no present."
+    match(
+      app_identifier: bundle_identifier,
+      type: match_type,
+      readonly: true
+    )
+
+  end
+
   desc "Adds a new device and regenerates the `Provisioning Profile`s to include it."
   lane :add_single_device do
 

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -206,19 +206,10 @@ reflected in `Info.plist` during building."
 
     build_configuration_key = options[:build_configuration]
     build_configuration = get_build_configuration(build_configuration: build_configuration_key)
-    match_type = get_match_type(build_configuration: build_configuration_key)
 
-    desc "Bundle identifier from xCode project"
-    bundle_identifier = read_project_property(
-      build_configuration: build_configuration,
-      build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
-    )
-
-    desc "Download provisioning profiles"
-    match(
-      app_identifier: bundle_identifier,
-      type: match_type,
-      readonly: true
+    desc "Download provisioning profile and certificates if no present."
+    refresh_certificates(
+      build_configuration: build_configuration_key
     )
 
     desc "Build the app using default project and scheme"

--- a/Fastfile.private
+++ b/Fastfile.private
@@ -207,7 +207,7 @@ reflected in `Info.plist` during building."
     build_configuration_key = options[:build_configuration]
     build_configuration = get_build_configuration(build_configuration: build_configuration_key)
 
-    desc "Download provisioning profile and certificates if no present."
+    desc "Download provisioning profile and certificates if not present."
     refresh_certificates(
       build_configuration: build_configuration_key
     )
@@ -256,7 +256,7 @@ reflected in `Info.plist` during building."
       skip_itc: skip_itc
     )
 
-    desc "Generate provisioning profile if no present"
+    desc "Generate provisioning profile if not present"
     match_result = match(
       app_identifier: bundle_identifier,
       type: match_type,
@@ -274,7 +274,7 @@ reflected in `Info.plist` during building."
 
   end
 
-  desc "Refreshes the `Certificates` and `Provisioning Profiles`."
+  desc "Updates or downloads the `Certificates` and `Provisioning Profiles`."
   private_lane :refresh_certificates do |options|
 
     build_configuration_key = options[:build_configuration]
@@ -287,7 +287,7 @@ reflected in `Info.plist` during building."
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
-    desc "Download provisioning profile and certificates if no present."
+    desc "Download provisioning profile and certificates if not present."
     match(
       app_identifier: bundle_identifier,
       type: match_type,

--- a/README.md
+++ b/README.md
@@ -99,6 +99,21 @@ Generates the push notifications certificates for the build configurations mappe
 fastlane ios generate_push_certificates_external_appstore
 ```
 Generates the push notifications certificates for the build configurations mapped to `:production`.
+### ios refresh_development_certificates
+```
+fastlane ios refresh_development_certificates
+```
+Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:test` and `:qa`.
+### ios refresh_internal_appstore_certificates
+```
+fastlane ios refresh_internal_appstore_certificates
+```
+Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:appstore`.
+### ios refresh_external_appstore_certificates
+```
+fastlane ios refresh_external_appstore_certificates
+```
+Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:production`.
 ### ios add_device
 ```
 fastlane ios add_device

--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ Generates the push notifications certificates for the build configurations mappe
 ```
 fastlane ios refresh_development_certificates
 ```
-Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:test` and `:qa`.
+Updates or downloads the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:test` and `:qa`.
 ### ios refresh_internal_appstore_certificates
 ```
 fastlane ios refresh_internal_appstore_certificates
 ```
-Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:appstore`.
+Updates or downloads the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:appstore`.
 ### ios refresh_external_appstore_certificates
 ```
 fastlane ios refresh_external_appstore_certificates
 ```
-Refreshes the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:production`.
+Updates or downloads the `Certificates` and `Provisioning Profiles` for the configurations mapped to `:production`.
 ### ios add_device
 ```
 fastlane ios add_device


### PR DESCRIPTION
Add lanes to refresh profiles and certificates in case other person in the team created them, and only has to download them without making any other action.