### PR TITLE
Support for multiple teams (first version)

### DIFF
--- a/Appfile
+++ b/Appfile
@@ -7,3 +7,25 @@ team_id "7XS5GQGS29"
 
 # iTunes Connect Team ID. (ex: "18742801")
 itc_team_id "95757806"
+
+# Secondary team (external) variables
+
+for_lane :release_external_appstore do
+  team_id ""
+  itc_team_id ""
+end
+
+for_lane :create_external_appstore_app do
+  team_id ""
+  itc_team_id ""
+end
+
+for_lane :generate_push_certificates_external_appstore do
+  team_id ""
+  itc_team_id ""
+end
+
+for_lane :refresh_external_appstore_certificates do
+  team_id ""
+  itc_team_id ""
+end

--- a/Matchfile
+++ b/Matchfile
@@ -10,3 +10,25 @@ git_branch "wolox-team"
 # Team ID for signing
 # Don't forget to change this in Appfile also.
 team_id "7XS5GQGS29"
+
+# Secondary team (external) variables
+
+for_lane :release_external_appstore do
+  git_branch ""
+  team_id ""
+end
+
+for_lane :create_external_appstore_app do
+  git_branch ""
+  team_id ""
+end
+
+for_lane :generate_push_certificates_external_appstore do
+  git_branch ""
+  team_id ""
+end
+
+for_lane :refresh_external_appstore_certificates do
+  git_branch ""
+  team_id ""
+end

--- a/actions/infer_bundle_identifier.rb
+++ b/actions/infer_bundle_identifier.rb
@@ -17,20 +17,15 @@ module Fastlane
         production: "com.%s.%s"
       }.freeze
 
-      # If the application is deployed in Wolox account choose Wolox
-      # as owner, otherwise choose project name.
-      DEPLOYED_IN_WOLOX_ACCOUNT = {
-        test: true,
-        qa: true,
-        appstore: true,
-        production: false
-      }.freeze
+      # Internal account team name to be used in bundle IDs.
+      INTERNAL_ACCOUNT_TEAM_NAME = 'Wolox'
 
       def self.run(params)
         # For legacy projects, just override the return value
         # with the desired bundle identifier.
         bundle_identifier_format = BUNDLE_IDENTIFIERS_FORMAT[params[:build_configuration]]
-        team_name = DEPLOYED_IN_WOLOX_ACCOUNT[params[:build_configuration]] ? "Wolox" : ProjectNameAction.default_project_name
+        uses_internal_account = Actions::UsesInternalAccountAction.run(params[:build_configuration])
+        team_name = uses_internal_account ? INTERNAL_ACCOUNT_TEAM_NAME : ProjectNameAction.default_project_name
         bundle_identifier_format % [team_name, ProjectNameAction.default_project_name]
       end
 

--- a/actions/uses_internal_account.rb
+++ b/actions/uses_internal_account.rb
@@ -1,0 +1,34 @@
+module Fastlane
+  module Actions
+    class UsesInternalAccountAction < Action
+
+      # Given a build configuration action
+      # this script returns if the application should use internal account.
+
+      # Whether application uses or not internal account.
+      USES_INTERNAL_ACCOUNT = {
+        test: true,
+        qa: true,
+        appstore: true,
+        production: false
+      }.freeze
+
+      def self.run(params)
+        USES_INTERNAL_ACCOUNT[params[:build_configuration]]
+      end
+
+      # Fastlane Action class required functions.
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :build_configuration, optional: false, is_string: false)
+        ]
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
First version.

Needless to say I don't like this approach since we need to repeat several times the IDs (for external team), but it's the only workaround I found so far. 

I prefer to have this working with no hardcoding and project custom changes, and send a PR that cleans this afterwards.