### PR TITLE
Compare versions as Gem::Version instead of String

### DIFF
--- a/actions/latest_testflight_version.rb
+++ b/actions/latest_testflight_version.rb
@@ -15,7 +15,10 @@ module Fastlane
         if app.nil?
           UI.abort_with_message! "The application with bundle ID '#{params[:bundle_id]}' is not yet created in iTunes Connect."
         end
-        app.all_build_train_numbers.max || params[:initial_version_number]
+        if app.all_build_train_numbers.empty?
+          return params[:initial_version_number]
+        end
+        app.all_build_train_numbers.map { |v| Gem::Version.new(v) }.max.to_s
       end
 
       # Fastlane Action class required functions.


### PR DESCRIPTION
Comparing versions using `Gem::Version` as suggested [here](https://github.com/fastlane/fastlane/issues/11544).

This works as expected supporting [semver](https://semver.org/) format.

```
[1] pry(main)> ["1.1.9", "1.1.10"].map { |v| Gem::Version.new(v) }.max.to_s
=> "1.1.10"
[2] pry(main)> ["1.1.9.beta1", "1.1.9.beta2"].map { |v| Gem::Version.new(v) }.max.to_s
=> "1.1.9.beta2"
```

@jcaracciolo apply this in your project and let me know if it's necessary to add something to `Gemfile` in order for this to work. I didn't need to add anything new.