### PR TITLE
[Pods] Fix Fastfile.private recognition of xcworkspace

### DIFF
--- a/fastlane/Fastfile.private
+++ b/fastlane/Fastfile.private
@@ -341,8 +341,8 @@ platform :ios do
       # http://krausefx.com/blog/download-dsym-symbolication-files-from-itunes-connect-for-bitcode-ios-apps
       include_bitcode: false
     }
-    if project_file.include? ".xcworkspace"
-      params[:workspace] = project_file
+    if File.exist?("#{ENV['PWD']}/#{project_name}.xcworkspace")
+      params[:workspace] = "#{project_name}.xcworkspace"
     else
       params[:project] = project_file
     end


### PR DESCRIPTION
### Summary
Fixed Fastfile.private to recognize xcworkspace

### Specific
Fixed the script to recognize existence of xcworkspace file to avoid build errors when using Pods

### Maybe Need Test
Is working on Projects that implement Pods, but we should check if work without pods, just in case.