### PR TITLE
Add API KEY support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ To add fastlane scripts to your project, you need to:
 - Copy the corresponding `fastlane` folder to your project's root dir
 - Run `bundle install` in your project's root dir
 - (Optional) You may want to add some fastlane noise to the .gitignore of your project, like the ones [here](./.gitignore).
+- You need to generate an API key for fastlane to use, it is no longer possible to use it with login credentials, you can generate an API key using the following [guide](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) (watch out, API keys can only be downloaded once from the appstore, so store it somewhere safe)
+- Once you have your API key you have to add the following keys to your .env files: KEY_ID (should be in the name of the file you downloaded from the appstore), ISSUER_ID (should be on the top part of the appstore page where you downloaded the key), KEY_FILEPATH (the path to your API key file)
+
 
 and that's it!
 

--- a/ios/fastlane/Fastfile.private
+++ b/ios/fastlane/Fastfile.private
@@ -191,18 +191,18 @@ platform :ios do
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
-    # TODO: check how to make this work again, for some reason it's throowing an authenticatioon error even with the API key configured
-    # desc "Read current version number from `TestFlight`."
-    # current_version_number = latest_testflight_version(
-    #   bundle_id: bundle_identifier,
-    #   initial_version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
-    #   username: credentials[:account],
-    #   team_id: credentials[:itc_team]
-    # )
+    check_app_store_metadata(include_in_app_purchases: false, app_identifier: bundle_identifier, default_rule_level: :warn)
 
-    current_version_number = lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION]
+    desc "Read current version number from `TestFlight`."
+    current_version_number = latest_testflight_version(
+      bundle_id: bundle_identifier,
+      initial_version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
+      username: credentials[:account],
+      team_id: credentials[:itc_team]
+    )
 
     desc "Read current build number from `TestFlight`."
+    
     current_build_number = latest_testflight_build_number(
       app_identifier: bundle_identifier,
       version: current_version_number,

--- a/ios/fastlane/Fastfile.private
+++ b/ios/fastlane/Fastfile.private
@@ -83,6 +83,15 @@ platform :ios do
       build_setting_value: bundle_id
     )
 
+    env_info = get_environment_info(environment: environment)
+    api_key = app_store_connect_api_key(
+      key_id: env_info["KEY_ID"],
+      issuer_id: env_info["ISSUER_ID"],
+      key_filepath: env_info["KEY_FILEPATH"],
+      duration: 1200, 
+      in_house: false,
+    )
+
   end
 
   private_lane :certificates_config do |options|
@@ -159,14 +168,15 @@ platform :ios do
   desc "First deploy must always be a '#{:major}'."
   private_lane :release do |options|
 
+    
     has_version_param = options[:version_number] != nil
     has_build_param = options[:build_number] != nil
-
+    
     environment = options[:environment]
     build_configuration = get_build_configuration(environment: environment)
     credentials = get_credentials(environment: environment)
     env_info = get_environment_info(environment: environment)
-
+    
     UI.message "Forced to version #{options[:version_number]}" if has_version_param
     UI.message "Forced to build #{options[:build_number]}" if has_build_param
 
@@ -181,13 +191,16 @@ platform :ios do
       build_setting: 'PRODUCT_BUNDLE_IDENTIFIER'
     )
 
-    desc "Read current version number from `TestFlight`."
-    current_version_number = latest_testflight_version(
-      bundle_id: bundle_identifier,
-      initial_version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
-      username: credentials[:account],
-      team_id: credentials[:itc_team]
-    )
+    # TODO: check how to make this work again, for some reason it's throowing an authenticatioon error even with the API key configured
+    # desc "Read current version number from `TestFlight`."
+    # current_version_number = latest_testflight_version(
+    #   bundle_id: bundle_identifier,
+    #   initial_version_number: Actions::CheckBumpTypeAction::FIRST_VERSION,
+    #   username: credentials[:account],
+    #   team_id: credentials[:itc_team]
+    # )
+
+    current_version_number = lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION]
 
     desc "Read current build number from `TestFlight`."
     current_build_number = latest_testflight_build_number(
@@ -468,7 +481,7 @@ platform :ios do
       username: credentials[:account],
       team_id: credentials[:team],
       git_url: certificates_info[:url],
-      git_branch: certificates_info[:branch],
+      git_branch: certificates_info[:branch]
     )
 
   end

--- a/ios/fastlane/actions/latest_testflight_version.rb
+++ b/ios/fastlane/actions/latest_testflight_version.rb
@@ -8,17 +8,22 @@ module Fastlane
 
       def self.run(params)
 
-        Spaceship::Tunes.login(params[:username])
-        Spaceship::Tunes.client.team_id = params[:team_id]
-
-        app = Spaceship::Tunes::Application.find(params[:bundle_id])
+        app = Spaceship::ConnectAPI::App.find(params[:bundle_id])
         if app.nil?
           UI.abort_with_message! "The application with bundle ID '#{params[:bundle_id]}' is not yet created in iTunes Connect."
         end
-        if app.all_build_train_numbers.empty?
+
+        v = app.get_edit_app_store_version
+
+        if v.nil?
+          v = app.get_live_app_store_version 
+        end
+        
+        if v.nil?
           return params[:initial_version_number]
         end
-        app.all_build_train_numbers.map { |v| Gem::Version.new(v) }.max.to_s
+
+        return v.versionString.length === 3 ? "#{v.versionString}.0" : v.versionString
       end
 
       # Fastlane Action class required functions.

--- a/ios/fastlane/config/dev.env
+++ b/ios/fastlane/config/dev.env
@@ -5,3 +5,12 @@ TEAM_ID="7XS5GQGS29"
 ITC_TEAM_ID="95757806"
 GIT_BRANCH="wolox-team"
 TEAM_NAME="Wolox"
+
+# Project config
+BUNDLE_ID=
+SCHEME=
+
+# Api key config, check readme for instructions on how to set it up with your account
+KEY_ID=
+ISSUER_ID=
+KEY_FILEPATH=

--- a/ios/fastlane/config/production.env
+++ b/ios/fastlane/config/production.env
@@ -5,3 +5,12 @@ TEAM_ID=""
 ITC_TEAM_ID=""
 GIT_BRANCH=""
 TEAM_NAME=""
+
+# Project config
+BUNDLE_ID=
+SCHEME=
+
+# Api key config, check readme for instructions on how to set it up with your account
+KEY_ID=
+ISSUER_ID=
+KEY_FILEPATH=

--- a/ios/fastlane/config/qa.env
+++ b/ios/fastlane/config/qa.env
@@ -5,3 +5,12 @@ TEAM_ID="7XS5GQGS29"
 ITC_TEAM_ID="95757806"
 GIT_BRANCH="wolox-team"
 TEAM_NAME="Wolox"
+
+# Project config
+BUNDLE_ID=
+SCHEME=
+
+# Api key config, check readme for instructions on how to set it up with your account
+KEY_ID=
+ISSUER_ID=
+KEY_FILEPATH=

--- a/ios/fastlane/config/stage.env
+++ b/ios/fastlane/config/stage.env
@@ -5,3 +5,12 @@ TEAM_ID=""
 ITC_TEAM_ID=""
 GIT_BRANCH=""
 TEAM_NAME=""
+
+# Project config
+BUNDLE_ID=
+SCHEME=
+
+# Api key config, check readme for instructions on how to set it up with your account
+KEY_ID=
+ISSUER_ID=
+KEY_FILEPATH=


### PR DESCRIPTION
2FA is now mandatory for the appstore, so we can't use credentials anymore, this PR lets you add an API key to connect to the appstore and avoid 2FA prompts.
